### PR TITLE
feat: add member authentication to dashboard #51

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TripController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TripController.java
@@ -45,9 +45,12 @@ public class TripController {
 
     @GetMapping("/trips/{tripId}")
     @ResponseStatus(HttpStatus.OK)
-    public TripGetDTO getTrip(@PathVariable Long tripId) {
+    public TripGetDTO getTrip(
+            @PathVariable Long tripId,
+            @RequestHeader("Authorization") String token) {
 
-        Trip trip = tripService.getTripById(tripId);
+        String rawToken = token.replace("Bearer ", "");
+        Trip trip = tripService.getTripById(tripId, rawToken);
 
         return DTOMapper.INSTANCE.convertEntityToTripGetDTO(trip);
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
@@ -72,9 +72,26 @@ public class TripService {
         return newTrip;
     }
 
-    public Trip getTripById(Long tripId) {
-        return tripRepository.findById(tripId)
+    public Trip getTripById(Long tripId, String token) {
+        // authenticate user
+        User user = userRepository.findByToken(token);
+        if (user == null) {
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED, "Invalid or missing token");
+        }
+
+        // find trip
+        Trip trip = tripRepository.findById(tripId)
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND, "Trip not found"));
+
+        // authorization: only trip members can access
+        // TODO: extend to all trip members once Member entity is implemented (S5)
+        if (!trip.getAdmin().getId().equals(user.getId())) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN, "User is not a member of this trip");
+        }
+
+        return trip;
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TripControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TripControllerTest.java
@@ -24,6 +24,7 @@ import java.time.LocalDateTime;
 
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -101,6 +102,46 @@ public class TripControllerTest {
 
         mockMvc.perform(postRequest)
                 .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void getTrip_validMember_returnsTrip() throws Exception {
+        User admin = new User();
+        admin.setId(1L);
+        admin.setUsername("alice");
+
+        Trip trip = new Trip();
+        trip.setTripId(1L);
+        trip.setTitle("Paris 2026");
+        trip.setLocation("Paris");
+        trip.setStartDate(LocalDate.of(2026, 8, 1));
+        trip.setEndDate(LocalDate.of(2026, 8, 10));
+        trip.setCreatedAt(LocalDateTime.of(2026, 6, 15, 10, 0));
+        trip.setInviteUrl("abc123");
+        trip.setAdmin(admin);
+
+        given(tripService.getTripById(Mockito.eq(1L), Mockito.anyString())).willReturn(trip);
+
+        MockHttpServletRequestBuilder getRequest = get("/trips/1")
+                .header("Authorization", "Bearer valid-token");
+
+        mockMvc.perform(getRequest)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tripId", is(1)))
+                .andExpect(jsonPath("$.title", is("Paris 2026")))
+                .andExpect(jsonPath("$.adminUsername", is("alice")));
+    }
+
+    @Test
+    public void getTrip_notMember_returnsForbidden() throws Exception {
+        given(tripService.getTripById(Mockito.anyLong(), Mockito.anyString()))
+                .willThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Not a member"));
+
+        MockHttpServletRequestBuilder getRequest = get("/trips/1")
+                .header("Authorization", "Bearer some-token");
+
+        mockMvc.perform(getRequest)
+                .andExpect(status().isForbidden());
     }
 
     private String asJsonString(final Object object) {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
@@ -94,5 +95,39 @@ public class TripServiceTest {
 
         assertThrows(ResponseStatusException.class,
                 () -> tripService.createTrip(input, "valid-token"));
+    }
+
+    @Test
+    public void getTripById_validAdmin_success() {
+        testTrip.setAdmin(testUser);
+        Mockito.when(tripRepository.findById(1L)).thenReturn(java.util.Optional.of(testTrip));
+
+        Trip found = tripService.getTripById(1L, "valid-token");
+
+        assertEquals(testTrip.getTripId(), found.getTripId());
+    }
+
+    @Test
+    public void getTripById_invalidToken_throwsUnauthorized() {
+        Mockito.when(userRepository.findByToken("bad-token")).thenReturn(null);
+
+        assertThrows(ResponseStatusException.class,
+                () -> tripService.getTripById(1L, "bad-token"));
+    }
+
+    @Test
+    public void getTripById_notMember_throwsForbidden() {
+        User otherUser = new User();
+        otherUser.setId(2L);
+        otherUser.setUsername("bob");
+        otherUser.setToken("bob-token");
+
+        testTrip.setAdmin(otherUser); // trip belongs to bob, not testUser
+
+        Mockito.when(tripRepository.findById(1L)).thenReturn(java.util.Optional.of(testTrip));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> tripService.getTripById(1L, "valid-token"));
+        assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
     }
 }


### PR DESCRIPTION
Implements authorization check for trip dashboard access (#51). Currently checks admin only; marked with TODO to extend to all trip members once Member entity is introduced in S5.