### PR TITLE
Feat/map-schedule

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/ActivityPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/ActivityPostDTO.java
@@ -6,6 +6,7 @@ import java.time.LocalTime;
 public class ActivityPostDTO {
 
     private Long bucketItemId;
+    private String name;
     private LocalDate date;
     private LocalTime startTime;
     private LocalTime endTime;
@@ -13,12 +14,20 @@ public class ActivityPostDTO {
     private Double latitude;
     private Double longitude;
 
-    public Long getBucketItemId() { 
-        return bucketItemId; 
+    public Long getBucketItemId() {
+        return bucketItemId;
     }
 
-    public void setBucketItemId(Long bucketItemId) { 
-        this.bucketItemId = bucketItemId; 
+    public void setBucketItemId(Long bucketItemId) {
+        this.bucketItemId = bucketItemId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public LocalDate getDate() { 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ActivityService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ActivityService.java
@@ -117,25 +117,35 @@ public class ActivityService {
         if (!trip.getMembers().contains(user)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You are not a member of this trip");
         }
-        BucketItem bucketItem = bucketItemRepository.findById(activityPostDTO.getBucketItemId())
-            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Bucket item not found"));
-
-        if (!bucketItem.getBucketTrip().getTripId().equals(tripId)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Bucket item does not belong to this trip");
-        }
         validateActivityTimes(activityPostDTO.getDate(), activityPostDTO.getStartTime(), activityPostDTO.getEndTime());
 
         Activity activity = new Activity();
-        activity.setName(bucketItem.getName());
         activity.setDate(activityPostDTO.getDate());
         activity.setStartTime(activityPostDTO.getStartTime());
         activity.setEndTime(activityPostDTO.getEndTime());
-        activity.setFromBucketItem(true);
         activity.setActivityTrip(trip);
-        activity.setBucketItem(bucketItem);
-        activity.setLocationName(activityPostDTO.getLocationName() != null ? activityPostDTO.getLocationName() : bucketItem.getLocation());
         activity.setLatitude(activityPostDTO.getLatitude());
         activity.setLongitude(activityPostDTO.getLongitude());
+
+        if (activityPostDTO.getBucketItemId() != null) {
+            BucketItem bucketItem = bucketItemRepository.findById(activityPostDTO.getBucketItemId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Bucket item not found"));
+            if (!bucketItem.getBucketTrip().getTripId().equals(tripId)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Bucket item does not belong to this trip");
+            }
+            activity.setName(bucketItem.getName());
+            activity.setFromBucketItem(true);
+            activity.setBucketItem(bucketItem);
+            activity.setLocationName(activityPostDTO.getLocationName() != null ? activityPostDTO.getLocationName() : bucketItem.getLocation());
+        } else {
+            if (activityPostDTO.getName() == null || activityPostDTO.getName().isBlank()) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "name is required when not scheduling from bucket");
+            }
+            activity.setName(activityPostDTO.getName());
+            activity.setFromBucketItem(false);
+            activity.setLocationName(activityPostDTO.getLocationName());
+        }
+
         return activityRepository.save(activity);
     }
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/ActivityServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/ActivityServiceTest.java
@@ -359,6 +359,37 @@ public class ActivityServiceTest {
         assertEquals("Custom Location", result.getLocationName());
     }
 
+    @Test
+    public void scheduleFromBucket_noNameAndNoBucketItem_throwsBadRequest() {
+        ActivityPostDTO dto = new ActivityPostDTO();
+        dto.setDate(LocalDate.of(2026, 8, 1));
+        dto.setStartTime(LocalTime.of(9, 0));
+        dto.setEndTime(LocalTime.of(11, 0));
+
+        assertThrows(ResponseStatusException.class,
+                () -> activityService.scheduleFromBucket(1L, dto, "valid-token"));
+    }
+
+    @Test
+    public void scheduleFromBucket_directFromMap_createsActivityWithProvidedName() {
+        Mockito.when(activityRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        ActivityPostDTO dto = new ActivityPostDTO();
+        dto.setName("Zurich Lake");
+        dto.setDate(LocalDate.of(2026, 8, 1));
+        dto.setStartTime(LocalTime.of(9, 0));
+        dto.setEndTime(LocalTime.of(11, 0));
+        dto.setLocationName("Zurich Lake, Switzerland");
+        dto.setLatitude(47.3769);
+        dto.setLongitude(8.5417);
+
+        Activity result = activityService.scheduleFromBucket(1L, dto, "valid-token");
+
+        assertEquals("Zurich Lake", result.getName());
+        assertFalse(result.isFromBucketItem());
+        assertEquals("Zurich Lake, Switzerland", result.getLocationName());
+    }
+
     // --- deleteActivity ---
 
     @Test


### PR DESCRIPTION
feat: allow users to add a map location directly to the trip timeline (#10)
- accept a place name and coordinates from the map when no bucket item is selected
- make the bucket item optional so activities can be created from any source
- keep the existing bucket item scheduling flow unchanged

test: verify activities can be created directly from a map location (https://github.com/tunaozdemir99/sopra-fs26-group-29-server/issues/10)
- confirm a bad request is returned when no name or bucket item is provided
- confirm an activity is saved correctly when a name and location are given from the map