### PR TITLE
feat: add database-level unique constraint on votes table to prevent duplicate votes per user per bucket item #73

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Vote.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Vote.java
@@ -4,7 +4,9 @@ import jakarta.persistence.*;
 import java.io.Serializable;
 
 @Entity
-@Table(name = "votes")
+@Table(name = "votes", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"user_id", "bucket_item_id"})
+})
 public class Vote implements Serializable {
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
Added database-level unique constraint on votes table to prevent duplicate votes on bucket items.