### PR TITLE
feat: delete trip when admin is the only member and leaves #124

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/MemberService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/MemberService.java
@@ -85,6 +85,10 @@ public class MemberService {
 
         // admin can't leave without transferring admin first
         if (isAdmin && isSelf) {
+            if (trip.getMembers().size() == 1) {
+                tripRepository.delete(trip);
+                return;
+            }
             throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST, "Transfer admin rights before leaving the trip");
         }


### PR DESCRIPTION
Delete the trip automatically when the admin is the only remaining member instead of blocking them from leaving.